### PR TITLE
selfservice: Explicitly whitelist form parser keys

### DIFF
--- a/selfservice/oidc/form.go
+++ b/selfservice/oidc/form.go
@@ -90,7 +90,9 @@ func merge(dc *selfservice.BodyDecoder, form string, traits json.RawMessage) (js
 		Traits map[string]interface{} `json:"traits"`
 	}
 
-	if err := dc.DecodeForm(q, &decodedForm); err != nil {
+	if err := dc.DecodeForm(q, &decodedForm, selfservice.BodyDecoderOptions{
+		AssertTypesForPrefix: "traits.",
+	}); err != nil {
 		return nil, err
 	}
 

--- a/selfservice/password/registration.go
+++ b/selfservice/password/registration.go
@@ -65,7 +65,7 @@ func (s *Strategy) handleRegistration(w http.ResponseWriter, r *http.Request, _ 
 	}
 
 	var p RegistrationFormPayload
-	if err := s.dec.Decode(r, &p); err != nil {
+	if err := s.dec.Decode(r, &p, selfservice.BodyDecoderOptions{AssertTypesForPrefix: "traits."}); err != nil {
 		s.handleRegistrationError(w, r, ar, err)
 		return
 	}

--- a/selfservice/password/registration_test.go
+++ b/selfservice/password/registration_test.go
@@ -241,6 +241,18 @@ func TestRegistration(t *testing.T) {
 			assert.Empty(t, gjson.GetBytes(body, "methods.password.config.error"))
 			assert.Contains(t, gjson.GetBytes(body, "methods.password.config.fields.traits\\.foobar.error").String(), "foobar is required", "%s", body)
 		})
+
+		t.Run("case=should work even if password is just numbers", func(t *testing.T) {
+			viper.Set(configuration.ViperKeyDefaultIdentityTraitsSchemaURL, "file://./stub/registration.schema.json")
+			rr := newRegistrationRequest(t, time.Minute)
+			body, res := makeRequest(t, rr.ID, url.Values{
+				"traits.username": {"registration-identifier-10"},
+				"password":        {"93172388957812344432"},
+				"traits.foobar":   {"bar"},
+			}.Encode(), http.StatusOK)
+			assert.Contains(t, res.Request.URL.Path, "return-ts")
+			assert.Equal(t, `registration-identifier-10`, gjson.GetBytes(body, "identity.traits.username").String(), "%s", body)
+		})
 	})
 
 	t.Run("method=PopulateSignUpMethod", func(t *testing.T) {


### PR DESCRIPTION
Previously the form parser would try to detect the field type by
asserting types for the whole form. That caused passwords
containing only numbers to fail to unmarshal into a string
value.

This patch resolves that issue by introducing a prefix
option to the BodyParser

Closes #98

